### PR TITLE
Tree hover event

### DIFF
--- a/dev/vscode-tree.html
+++ b/dev/vscode-tree.html
@@ -223,6 +223,12 @@
             tree.addEventListener('vsc-select', (ev) => {
               console.log(ev);
             });
+            tree.addEventListener('vsc-hover', (ev) => {
+              console.log(ev);
+            });
+            tree.addEventListener('vsc-hover-leave', (ev) => {
+              console.log(ev);
+            });
           });
         </script>
       </component-preview>

--- a/src/vscode-tree/vscode-tree.styles.ts
+++ b/src/vscode-tree/vscode-tree.styles.ts
@@ -206,6 +206,11 @@ const styles: CSSResultGroup = [
       color: var(--vscode-list-hoverForeground);
     }
 
+    .contents.hovered {
+      background-color: var(--vscode-list-hoverBackground);
+      color: var(--vscode-list-hoverForeground);
+    }
+    
     .contents:hover,
     .contents.selected:hover {
       outline-color: var(--hover-outline-color);

--- a/src/vscode-tree/vscode-tree.ts
+++ b/src/vscode-tree/vscode-tree.ts
@@ -151,10 +151,9 @@ const isBranch = (item: TreeItem) => {
 /**
  * @fires vsc-select Dispatched when an item is selected. The event data shape is described in the
  * `SelectEventDetail` interface.
- * @fires vsc-focus Dispatched when an item is focused. The event data shape is described in the
- * `FocusEventDetail` interface.
- * @fires vsc-hover Dispatched when an item is focused. The event data shape is described in the
- * `FocusEventDetail` interface (no difference with a `vsc-focus` event, except the event type).
+ * @fires vsc-hover Dispatched when an item is hovered. The event data shape is described in the
+ * `HoverEventDetail` interface.
+ * @fires vsc-hover-leave Dispatched when the tree is no longer hovered. This event has no associated data.
  * @fires vsc-run-action Dispatched when an action icon is clicked.
  *
  * @cssprop --vscode-focusBorder

--- a/src/vscode-tree/vscode-tree.ts
+++ b/src/vscode-tree/vscode-tree.ts
@@ -238,6 +238,10 @@ export class VscodeTree extends VscElement {
     this._hoverItem(item, false);  // hover but do not emit event
   }
 
+  public hoverReset() {
+    this._hoverReset();
+  }
+
   connectedCallback(): void {
     super.connectedCallback();
     this.addEventListener('keydown', this._handleComponentKeyDownBound);
@@ -743,6 +747,13 @@ export class VscodeTree extends VscElement {
     }
   }
 
+  private _hoverReset() {
+    if (this._hoveredItem) {
+      this._hoveredItem.hovered = false;
+    }
+    this._hoveredItem = null;
+  }
+
   private _closeSubTreeRecursively(tree: TreeItem[]) {
     tree.forEach((item) => {
       item.open = false;
@@ -788,6 +799,15 @@ export class VscodeTree extends VscElement {
         bubbles: true,
         composed: true,
         detail,
+      })
+    );
+  }
+
+  private _emitHoverLeaveEvent() {
+    this.dispatchEvent(
+      new CustomEvent('vsc-hover-leave', {
+        bubbles: true,
+        composed: true,
       })
     );
   }
@@ -866,6 +886,11 @@ export class VscodeTree extends VscElement {
         }
       }
     }
+  }
+
+  private _handleMouseLeave() {
+    this._emitHoverLeaveEvent();
+    this._hoverReset();
   }
 
   private _handleMouseOver(event: MouseEvent) {
@@ -956,7 +981,7 @@ export class VscodeTree extends VscElement {
     });
 
     return html`
-      <div @click="${this._handleClick}" @mouseover="${this._handleMouseOver}" class="${classes}">
+      <div @click="${this._handleClick}" @mouseover="${this._handleMouseOver}" @mouseleave="${this._handleMouseLeave}" class="${classes}">
         <ul>
           ${this._renderTree(this._data)}
         </ul>


### PR DESCRIPTION
Emit 'vsc-hover' and 'vsc-hover-leave' events to synchronize multiple trees together.
Allows to programmatically set TreeItem items as 'selected' or 'hovered'